### PR TITLE
Adding guard to prevent dev tools throwing console error

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,11 @@ export function disableReactDevTools() {
 
   // Replace all global hook properties with a no-op function or a null value
   for (const prop in window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+    if (prop === "renderers") {
+      // prevents console error when dev tools try to iterate of renderers
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = new Map();
+      continue;
+    }
     window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = isFunction(
       window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop]
     )


### PR DESCRIPTION
Added a guard to check for the `renderers` property to instantiate a new `Map` so when dev tools attempt to iterate over the original map there is not a `null` exception.

addresses #6