### PR TITLE
adds support for nextjs apps

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -6,3 +6,7 @@ export function isObject(obj) {
   var type = typeof obj;
   return type === 'function' || (type === 'object' && !!obj);
 }
+
+export function hasWindowObject() {
+  return typeof window !== 'undefined' && window.document;
+}

--- a/index.js
+++ b/index.js
@@ -1,22 +1,24 @@
-import { isFunction, isObject } from './helpers';
+import { isFunction, isObject, hasWindowObject } from './helpers';
 
 export function disableReactDevTools() {
-  // Ensure the React Developer Tools global hook exists
-  if (!isObject(window.__REACT_DEVTOOLS_GLOBAL_HOOK__)) {
-    return;
-  }
-
-  // Replace all global hook properties with a no-op function or a null value
-  for (const prop in window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
-    if (prop === "renderers") {
-      // prevents console error when dev tools try to iterate of renderers
-      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = new Map();
-      continue;
+  if (hasWindowObject()) {
+    // Ensure the React Developer Tools global hook exists
+    if (!isObject(window.__REACT_DEVTOOLS_GLOBAL_HOOK__)) {
+      return;
     }
-    window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = isFunction(
-      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop]
-    )
-      ? Function.prototype
-      : null;
+
+    // Replace all global hook properties with a no-op function or a null value
+    for (const prop in window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+      if (prop === 'renderers') {
+        // prevents console error when dev tools try to iterate of renderers
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = new Map();
+        continue;
+      }
+      window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop] = isFunction(
+        window.__REACT_DEVTOOLS_GLOBAL_HOOK__[prop]
+      )
+        ? Function.prototype
+        : null;
+    }
   }
 }


### PR DESCRIPTION
Adds support for applications made with nextjs. The error `Window is not defined` occurs because window is not yet available, while component is still mounting via SSR.

This verification does not impact applications made with CRA.


Fix: #8 